### PR TITLE
Can now use "Both" when rendering a sprite to render a square sprite

### DIFF
--- a/EditorExtensions/Images/Sprite/SpriteDirection.cs
+++ b/EditorExtensions/Images/Sprite/SpriteDirection.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MadsKristensen.EditorExtensions.Images
+{
+  public enum SpriteDirection
+  {
+    Vertical,
+    Horizontal,
+    Both
+  }
+}

--- a/EditorExtensions/Images/Sprite/SpriteDocument.cs
+++ b/EditorExtensions/Images/Sprite/SpriteDocument.cs
@@ -9,182 +9,184 @@ using MadsKristensen.EditorExtensions.Settings;
 
 namespace MadsKristensen.EditorExtensions.Images
 {
-    internal class SpriteDocument : IBundleDocument
+  internal class SpriteDocument : IBundleDocument
+  {
+    public string FileName { get; set; }
+    public IEnumerable<string> BundleAssets { get; set; }
+    public bool Optimize { get; set; }
+    public SpriteDirection Direction { get; set; }
+    public int Margin { get; set; }
+    public bool RunOnBuild { get; set; }
+    public string FileExtension { get; set; }
+    public bool UseFullPathForIdentifierName { get; set; }
+    public bool UseAbsoluteUrl { get; set; }
+    public string OutputDirectory { get; set; }
+    public string CssOutputDirectory { get; set; }
+    public string LessOutputDirectory { get; set; }
+    public string ScssOutputDirectory { get; set; }
+
+    public SpriteDocument(string fileName, params string[] imageFiles)
     {
-        public string FileName { get; set; }
-        public IEnumerable<string> BundleAssets { get; set; }
-        public bool Optimize { get; set; }
-        public bool IsVertical { get; set; }
-        public int Margin { get; set; }
-        public bool RunOnBuild { get; set; }
-        public string FileExtension { get; set; }
-        public bool UseFullPathForIdentifierName { get; set; }
-        public bool UseAbsoluteUrl { get; set; }
-        public string OutputDirectory { get; set; }
-        public string CssOutputDirectory { get; set; }
-        public string LessOutputDirectory { get; set; }
-        public string ScssOutputDirectory { get; set; }
-
-        public SpriteDocument(string fileName, params string[] imageFiles)
-        {
-            FileName = fileName;
-            BundleAssets = imageFiles;
-            FileExtension = Path.GetExtension(imageFiles.First()).TrimStart('.');
-            Optimize = WESettings.Instance.Sprite.Optimize;
-            IsVertical = WESettings.Instance.Sprite.IsVertical;
-            Margin = WESettings.Instance.Sprite.Margin;
-            RunOnBuild = WESettings.Instance.Sprite.RunOnBuild;
-            UseFullPathForIdentifierName = WESettings.Instance.Sprite.UseFullPathForIdentifierName;
-            UseAbsoluteUrl = WESettings.Instance.Sprite.UseAbsoluteUrl;
-            OutputDirectory = WESettings.Instance.Sprite.OutputDirectory;
-            CssOutputDirectory = WESettings.Instance.Sprite.CssOutputDirectory;
-            LessOutputDirectory = WESettings.Instance.Sprite.LessOutputDirectory;
-            ScssOutputDirectory = WESettings.Instance.Sprite.ScssOutputDirectory;
-        }
-
-        public async Task<XDocument> WriteSpriteRecipe()
-        {
-            string root = ProjectHelpers.GetRootFolder();
-            XmlWriterSettings settings = new XmlWriterSettings() { Indent = true };
-            XNamespace xsi = "http://www.w3.org/2001/XMLSchema-instance";
-
-            if (string.IsNullOrEmpty(root))
-                root = ProjectHelpers.GetProjectFolder(FileName);
-
-            ProjectHelpers.CheckOutFileFromSourceControl(FileName);
-
-            using (XmlWriter writer = await Task.Run(() => XmlWriter.Create(FileName, settings)))
-            {
-                XDocument doc =
-                new XDocument(
-                    new XElement("sprite",
-                        new XAttribute(XNamespace.Xmlns + "xsi", xsi),
-                        new XAttribute(xsi + "noNamespaceSchemaLocation", "http://vswebessentials.com/schemas/v1/sprite.xsd"),
-                        new XElement("settings",
-                            new XComment("Determines if the sprite image should be automatically optimized after creation/update."),
-                            new XElement("optimize", Optimize.ToString().ToLowerInvariant()),
-                            new XComment("Determines the orientation of images to form this sprite. The value must be vertical or horizontal."),
-                            new XElement("orientation", IsVertical ? "vertical" : "horizontal"),
-                            new XComment("The margin (in pixel) around and between the constituent images."),
-                            new XElement("margin", Margin),
-                            new XComment("File extension of sprite image."),
-                            new XElement("outputType", FileExtension.ToString().ToLowerInvariant()),
-                            new XComment("Determine whether to generate/re-generate this sprite on building the solution."),
-                            new XElement("runOnBuild", RunOnBuild.ToString().ToLowerInvariant()),
-                            new XComment("Use full path to generate unique class or mixin name in CSS, LESS and SASS files. Consider disabling this if you want class names to be filename only."),
-                            new XElement("fullPathForIdentifierName", UseFullPathForIdentifierName.ToString().ToLowerInvariant()),
-                            new XComment("Use absolute path in the generated CSS-like files. By default, the URLs are relative to sprite image file (and the location of CSS, LESS and SCSS)."),
-                            new XElement("useAbsoluteUrl", UseAbsoluteUrl.ToString().ToLowerInvariant()),
-                            new XComment("Specifies a custom subfolder to save files to. By default, compiled output will be placed in the same folder and nested under the original file."),
-                            new XElement("outputDirectory", OutputDirectory),
-                            new XComment("Specifies a custom subfolder to save CSS files to. By default, compiled output will be placed in the same folder and nested under the original file."),
-                            new XElement("outputDirectoryForCss", CssOutputDirectory),
-                            new XComment("Specifies a custom subfolder to save LESS files to. By default, compiled output will be placed in the same folder and nested under the original file."),
-                            new XElement("outputDirectoryForLess", LessOutputDirectory),
-                            new XComment("Specifies a custom subfolder to save SCSS files to. By default, compiled output will be placed in the same folder and nested under the original file."),
-                            new XElement("outputDirectoryForScss", ScssOutputDirectory)
-                        ),
-                        new XComment("The order of the <file> elements determines the order of the images in the sprite."),
-                        new XElement("files", BundleAssets.Select(file => new XElement("file", "/" + FileHelpers.RelativePath(root, file))))
-                    )
-                );
-
-                doc.Save(writer);
-
-                return doc;
-            }
-        }
-
-        public async Task<IBundleDocument> LoadFromFile(string fileName)
-        {
-            return await SpriteDocument.FromFile(fileName);
-        }
-
-        public static async Task<SpriteDocument> FromFile(string fileName)
-        {
-            string root = ProjectHelpers.GetProjectFolder(fileName);
-            string folder = Path.GetDirectoryName(root);
-
-            if (folder == null || root == null)
-                return null;
-
-            XDocument doc = null;
-
-            string contents = await FileHelpers.ReadAllTextRetry(fileName);
-
-            try
-            {
-                doc = XDocument.Parse(contents);
-            }
-            catch (XmlException)
-            {
-                return null;
-            }
-
-            XElement element = null;
-
-            IEnumerable<string> imageFiles = ProjectHelpers.GetBundleConstituentFiles(doc.Descendants("file").Select(s => s.Value), root, folder, fileName);
-
-            SpriteDocument sprite = new SpriteDocument(fileName, imageFiles.ToArray());
-
-            element = doc.Descendants("optimize").FirstOrDefault();
-
-            if (element != null)
-                sprite.Optimize = element.Value.Equals("true", StringComparison.OrdinalIgnoreCase);
-
-            element = doc.Descendants("orientation").FirstOrDefault();
-
-            if (element != null)
-                sprite.IsVertical = element.Value.Equals("vertical", StringComparison.OrdinalIgnoreCase);
-
-            element = doc.Descendants("margin").FirstOrDefault();
-
-            sprite.Margin = WESettings.Instance.Sprite.Margin; // So the current implementation (without margin support) doesn't break.
-
-            if (element != null)
-                sprite.Margin = int.Parse(element.Value);
-
-            element = doc.Descendants("runOnBuild").FirstOrDefault();
-
-            if (element != null)
-                sprite.RunOnBuild = element.Value.Equals("true", StringComparison.OrdinalIgnoreCase);
-
-            element = doc.Descendants("outputType").FirstOrDefault();
-
-            if (element != null)
-                sprite.FileExtension = element.Value;
-
-            element = doc.Descendants("fullPathForIdentifierName").FirstOrDefault();
-
-            if (element != null)
-                sprite.UseFullPathForIdentifierName = element.Value.Equals("true", StringComparison.OrdinalIgnoreCase);
-
-            element = doc.Descendants("outputDirectory").FirstOrDefault();
-
-            if (element != null)
-                sprite.OutputDirectory = element.Value;
-
-            element = doc.Descendants("useAbsoluteUrl").FirstOrDefault();
-
-            if (element != null)
-                sprite.UseAbsoluteUrl = element.Value.Equals("true", StringComparison.OrdinalIgnoreCase);
-
-            element = doc.Descendants("outputDirectoryForCss").FirstOrDefault();
-
-            if (element != null)
-                sprite.CssOutputDirectory = element.Value;
-
-            element = doc.Descendants("outputDirectoryForLess").FirstOrDefault();
-
-            if (element != null)
-                sprite.LessOutputDirectory = element.Value;
-
-            element = doc.Descendants("outputDirectoryForScss").FirstOrDefault();
-
-            if (element != null)
-                sprite.ScssOutputDirectory = element.Value;
-
-            return sprite;
-        }
+      FileName = fileName;
+      BundleAssets = imageFiles;
+      FileExtension = Path.GetExtension(imageFiles.First()).TrimStart('.');
+      Optimize = WESettings.Instance.Sprite.Optimize;
+      Direction = WESettings.Instance.Sprite.Direction;
+      Margin = WESettings.Instance.Sprite.Margin;
+      RunOnBuild = WESettings.Instance.Sprite.RunOnBuild;
+      UseFullPathForIdentifierName = WESettings.Instance.Sprite.UseFullPathForIdentifierName;
+      UseAbsoluteUrl = WESettings.Instance.Sprite.UseAbsoluteUrl;
+      OutputDirectory = WESettings.Instance.Sprite.OutputDirectory;
+      CssOutputDirectory = WESettings.Instance.Sprite.CssOutputDirectory;
+      LessOutputDirectory = WESettings.Instance.Sprite.LessOutputDirectory;
+      ScssOutputDirectory = WESettings.Instance.Sprite.ScssOutputDirectory;
     }
+
+    public async Task<XDocument> WriteSpriteRecipe()
+    {
+      string root = ProjectHelpers.GetRootFolder();
+      XmlWriterSettings settings = new XmlWriterSettings() { Indent = true };
+      XNamespace xsi = "http://www.w3.org/2001/XMLSchema-instance";
+
+      if (string.IsNullOrEmpty(root))
+        root = ProjectHelpers.GetProjectFolder(FileName);
+
+      ProjectHelpers.CheckOutFileFromSourceControl(FileName);
+
+      using (XmlWriter writer = await Task.Run(() => XmlWriter.Create(FileName, settings)))
+      {
+        XDocument doc =
+        new XDocument(
+            new XElement("sprite",
+                new XAttribute(XNamespace.Xmlns + "xsi", xsi),
+                new XAttribute(xsi + "noNamespaceSchemaLocation", "http://vswebessentials.com/schemas/v1/sprite.xsd"),
+                new XElement("settings",
+                    new XComment("Determines if the sprite image should be automatically optimized after creation/update."),
+                    new XElement("optimize", Optimize.ToString().ToLowerInvariant()),
+                    new XComment("Determines the orientation of images to form this sprite. The value must be vertical or horizontal."),
+                    new XElement("orientation", Direction == SpriteDirection.Both ? "both" :
+                      (Direction == SpriteDirection.Horizontal ? "horizontal" : "vertical")),
+                    new XComment("The margin (in pixel) around and between the constituent images."),
+                    new XElement("margin", Margin),
+                    new XComment("File extension of sprite image."),
+                    new XElement("outputType", FileExtension.ToString().ToLowerInvariant()),
+                    new XComment("Determine whether to generate/re-generate this sprite on building the solution."),
+                    new XElement("runOnBuild", RunOnBuild.ToString().ToLowerInvariant()),
+                    new XComment("Use full path to generate unique class or mixin name in CSS, LESS and SASS files. Consider disabling this if you want class names to be filename only."),
+                    new XElement("fullPathForIdentifierName", UseFullPathForIdentifierName.ToString().ToLowerInvariant()),
+                    new XComment("Use absolute path in the generated CSS-like files. By default, the URLs are relative to sprite image file (and the location of CSS, LESS and SCSS)."),
+                    new XElement("useAbsoluteUrl", UseAbsoluteUrl.ToString().ToLowerInvariant()),
+                    new XComment("Specifies a custom subfolder to save files to. By default, compiled output will be placed in the same folder and nested under the original file."),
+                    new XElement("outputDirectory", OutputDirectory),
+                    new XComment("Specifies a custom subfolder to save CSS files to. By default, compiled output will be placed in the same folder and nested under the original file."),
+                    new XElement("outputDirectoryForCss", CssOutputDirectory),
+                    new XComment("Specifies a custom subfolder to save LESS files to. By default, compiled output will be placed in the same folder and nested under the original file."),
+                    new XElement("outputDirectoryForLess", LessOutputDirectory),
+                    new XComment("Specifies a custom subfolder to save SCSS files to. By default, compiled output will be placed in the same folder and nested under the original file."),
+                    new XElement("outputDirectoryForScss", ScssOutputDirectory)
+                ),
+                new XComment("The order of the <file> elements determines the order of the images in the sprite."),
+                new XElement("files", BundleAssets.Select(file => new XElement("file", "/" + FileHelpers.RelativePath(root, file))))
+            )
+        );
+
+        doc.Save(writer);
+
+        return doc;
+      }
+    }
+
+    public async Task<IBundleDocument> LoadFromFile(string fileName)
+    {
+      return await SpriteDocument.FromFile(fileName);
+    }
+
+    public static async Task<SpriteDocument> FromFile(string fileName)
+    {
+      string root = ProjectHelpers.GetProjectFolder(fileName);
+      string folder = Path.GetDirectoryName(root);
+
+      if (folder == null || root == null)
+        return null;
+
+      XDocument doc = null;
+
+      string contents = await FileHelpers.ReadAllTextRetry(fileName);
+
+      try
+      {
+        doc = XDocument.Parse(contents);
+      }
+      catch (XmlException)
+      {
+        return null;
+      }
+
+      XElement element = null;
+
+      IEnumerable<string> imageFiles = ProjectHelpers.GetBundleConstituentFiles(doc.Descendants("file").Select(s => s.Value), root, folder, fileName);
+
+      SpriteDocument sprite = new SpriteDocument(fileName, imageFiles.ToArray());
+
+      element = doc.Descendants("optimize").FirstOrDefault();
+
+      if (element != null)
+        sprite.Optimize = element.Value.Equals("true", StringComparison.OrdinalIgnoreCase);
+
+      element = doc.Descendants("orientation").FirstOrDefault();
+
+      if (element != null)
+        sprite.Direction = element.Value.Equals("vertical", StringComparison.OrdinalIgnoreCase) ? SpriteDirection.Vertical :
+          (element.Value.Equals("horizontal", StringComparison.OrdinalIgnoreCase) ? SpriteDirection.Horizontal : SpriteDirection.Both);
+
+      element = doc.Descendants("margin").FirstOrDefault();
+
+      sprite.Margin = WESettings.Instance.Sprite.Margin; // So the current implementation (without margin support) doesn't break.
+
+      if (element != null)
+        sprite.Margin = int.Parse(element.Value);
+
+      element = doc.Descendants("runOnBuild").FirstOrDefault();
+
+      if (element != null)
+        sprite.RunOnBuild = element.Value.Equals("true", StringComparison.OrdinalIgnoreCase);
+
+      element = doc.Descendants("outputType").FirstOrDefault();
+
+      if (element != null)
+        sprite.FileExtension = element.Value;
+
+      element = doc.Descendants("fullPathForIdentifierName").FirstOrDefault();
+
+      if (element != null)
+        sprite.UseFullPathForIdentifierName = element.Value.Equals("true", StringComparison.OrdinalIgnoreCase);
+
+      element = doc.Descendants("outputDirectory").FirstOrDefault();
+
+      if (element != null)
+        sprite.OutputDirectory = element.Value;
+
+      element = doc.Descendants("useAbsoluteUrl").FirstOrDefault();
+
+      if (element != null)
+        sprite.UseAbsoluteUrl = element.Value.Equals("true", StringComparison.OrdinalIgnoreCase);
+
+      element = doc.Descendants("outputDirectoryForCss").FirstOrDefault();
+
+      if (element != null)
+        sprite.CssOutputDirectory = element.Value;
+
+      element = doc.Descendants("outputDirectoryForLess").FirstOrDefault();
+
+      if (element != null)
+        sprite.LessOutputDirectory = element.Value;
+
+      element = doc.Descendants("outputDirectoryForScss").FirstOrDefault();
+
+      if (element != null)
+        sprite.ScssOutputDirectory = element.Value;
+
+      return sprite;
+    }
+  }
 }

--- a/EditorExtensions/Images/Sprite/SpriteDocument.cs
+++ b/EditorExtensions/Images/Sprite/SpriteDocument.cs
@@ -64,8 +64,7 @@ namespace MadsKristensen.EditorExtensions.Images
                     new XComment("Determines if the sprite image should be automatically optimized after creation/update."),
                     new XElement("optimize", Optimize.ToString().ToLowerInvariant()),
                     new XComment("Determines the orientation of images to form this sprite. The value must be vertical or horizontal."),
-                    new XElement("orientation", Direction == SpriteDirection.Both ? "both" :
-                      (Direction == SpriteDirection.Horizontal ? "horizontal" : "vertical")),
+                    new XElement("orientation", Enum.GetName(typeof(SpriteDirection), Direction).ToLowerInvariant()),
                     new XComment("The margin (in pixel) around and between the constituent images."),
                     new XElement("margin", Margin),
                     new XComment("File extension of sprite image."),
@@ -136,9 +135,11 @@ namespace MadsKristensen.EditorExtensions.Images
       element = doc.Descendants("orientation").FirstOrDefault();
 
       if (element != null)
-        sprite.Direction = element.Value.Equals("vertical", StringComparison.OrdinalIgnoreCase) ? SpriteDirection.Vertical :
-          (element.Value.Equals("horizontal", StringComparison.OrdinalIgnoreCase) ? SpriteDirection.Horizontal : SpriteDirection.Both);
+      {
+        SpriteDirection direction = Enum.TryParse<SpriteDirection>(element.Value.ToString(), true, out direction) ? direction : SpriteDirection.Vertical;
+        sprite.Direction = direction;
 
+      }
       element = doc.Descendants("margin").FirstOrDefault();
 
       sprite.Margin = WESettings.Instance.Sprite.Margin; // So the current implementation (without margin support) doesn't break.

--- a/EditorExtensions/Images/Sprite/SpriteGenerator.cs
+++ b/EditorExtensions/Images/Sprite/SpriteGenerator.cs
@@ -34,7 +34,7 @@ namespace MadsKristensen.EditorExtensions.Images
         var rows = Math.Floor(sqrt) != Math.Ceiling(sqrt) ? cols + 1 : cols;
         // In this case, the remainder will create another row
         width = (images.Values.Max(img => img.Width) * cols) + (document.Margin * cols) + document.Margin;
-        height = (images.Values.Max(img => img.Height) * rows) + (document.Margin * rows) + document.Margin;
+        height = (images.Values.Max(img => img.Height) * (rows + 1)) + (document.Margin * (rows + 1)) + document.Margin;
       }
 
       List<SpriteFragment> fragments = new List<SpriteFragment>();
@@ -85,13 +85,12 @@ namespace MadsKristensen.EditorExtensions.Images
       int currentY = margin;
       int currentX = margin;
 
-      var sqrt = Math.Sqrt(images.Count);
-
+      // Lazy way of making sure images don't overlap is to make ALL OF THEM to be the size of the largest one
       var rowHeight = images.Max(img => img.Value.Height);
       var colWidth = images.Max(img => img.Value.Width);
 
-      var cols = Convert.ToInt32(sqrt);
-      // In this case, the remainder will create another row
+      var cols = Convert.ToInt32(Math.Floor(Math.Sqrt(images.Count)));
+      
       Queue<String> imageQueue = new Queue<String>(images.Keys);
 
       while (imageQueue.Count > 0)

--- a/EditorExtensions/Images/Sprite/SpriteGenerator.cs
+++ b/EditorExtensions/Images/Sprite/SpriteGenerator.cs
@@ -6,97 +6,154 @@ using System.Threading.Tasks;
 
 namespace MadsKristensen.EditorExtensions.Images
 {
-    internal static class SpriteGenerator
+  internal static class SpriteGenerator
+  {
+    public async static Task<IEnumerable<SpriteFragment>> MakeImage(SpriteDocument document, string imageFile, Func<string, bool, Task> updateSprite)
     {
-        public async static Task<IEnumerable<SpriteFragment>> MakeImage(SpriteDocument document, string imageFile, Func<string, bool, Task> updateSprite)
+      ProjectHelpers.CheckOutFileFromSourceControl(imageFile);
+
+      Dictionary<string, Image> images = await WatchFiles(document, updateSprite);
+
+      var width = 0;
+      var height = 0;
+      
+      if (document.Direction == SpriteDirection.Vertical)
+      {
+        width = images.Values.Max(i => i.Width) + (document.Margin * 2);
+        height = images.Values.Sum(img => img.Height) + (document.Margin * images.Count);
+      }
+      else if (document.Direction == SpriteDirection.Horizontal)
+      {
+        width = images.Values.Sum(i => i.Width) + (document.Margin * images.Count) + document.Margin;
+        height = images.Values.Max(img => img.Height) + (document.Margin * 2);
+      }
+      else if (document.Direction == SpriteDirection.Both)
+      {
+        var sqrt = Math.Sqrt(images.Count);
+        var cols = Convert.ToInt32(Math.Floor(sqrt));
+        var rows = Math.Floor(sqrt) != Math.Ceiling(sqrt) ? cols + 1 : cols;
+        // In this case, the remainder will create another row
+        width = (images.Values.Max(img => img.Width) * cols) + (document.Margin * cols) + document.Margin;
+        height = (images.Values.Max(img => img.Height) * rows) + (document.Margin * rows) + document.Margin;
+      }
+
+      List<SpriteFragment> fragments = new List<SpriteFragment>();
+
+      using (var bitmap = new Bitmap(width, height))
+      {
+        using (Graphics canvas = Graphics.FromImage(bitmap))
         {
-            ProjectHelpers.CheckOutFileFromSourceControl(imageFile);
+          switch (document.Direction)
+          {
+          case SpriteDirection.Both:
+            Both(images, fragments, canvas, document.Margin);
+            break;
+          case SpriteDirection.Horizontal:
+            Horizontal(images, fragments, canvas, document.Margin);
+            break;
+          case SpriteDirection.Vertical:
+          default:
+            Vertical(images, fragments, canvas, document.Margin);
+            break;
+          }
 
-            Dictionary<string, Image> images = await WatchFiles(document, updateSprite);
-
-            int width = document.IsVertical ? images.Values.Max(i => i.Width) + (document.Margin * 2) : images.Values.Sum(i => i.Width) + (document.Margin * images.Count) + document.Margin;
-            int height = document.IsVertical ? images.Values.Sum(img => img.Height) + (document.Margin * images.Count) + document.Margin : images.Values.Max(img => img.Height) + (document.Margin * 2);
-
-            List<SpriteFragment> fragments = new List<SpriteFragment>();
-
-            using (var bitmap = new Bitmap(width, height))
-            {
-                using (Graphics canvas = Graphics.FromImage(bitmap))
-                {
-                    if (document.IsVertical)
-                        Vertical(images, fragments, canvas, document.Margin);
-                    else
-                        Horizontal(images, fragments, canvas, document.Margin);
-                }
-
-                bitmap.Save(imageFile, PasteImage.GetImageFormat("." + document.FileExtension));
-            }
-
-            return fragments;
+          bitmap.Save(imageFile, PasteImage.GetImageFormat("." + document.FileExtension));
         }
+      }
 
-        public async static Task<Dictionary<string, Image>> WatchFiles(SpriteDocument document, Func<string, bool, Task> updateSprite)
-        {
-            if (document == null)
-                return null;
-
-            Dictionary<string, Image> images = GetImages(document);
-
-            await new BundleFileObserver().AttachFileObserver(document, document.FileName, updateSprite);
-
-            foreach (string file in images.Keys)
-            {
-                await new BundleFileObserver().AttachFileObserver(document, file, updateSprite);
-            }
-
-            return images;
-        }
-
-        private static void Vertical(Dictionary<string, Image> images, List<SpriteFragment> fragments, Graphics canvas, int margin)
-        {
-            int currentY = margin;
-
-            foreach (string file in images.Keys)
-            {
-                Image img = images[file];
-                fragments.Add(new SpriteFragment(file, img.Width, img.Height, margin, currentY));
-
-                canvas.DrawImage(img, margin, currentY);
-                currentY += img.Height + margin;
-            }
-        }
-
-        private static void Horizontal(Dictionary<string, Image> images, List<SpriteFragment> fragments, Graphics canvas, int margin)
-        {
-            int currentX = margin;
-
-            foreach (string file in images.Keys)
-            {
-                Image img = images[file];
-                fragments.Add(new SpriteFragment(file, img.Width, img.Height, currentX, margin));
-
-                canvas.DrawImage(img, currentX, margin);
-                currentX += img.Width + margin;
-            }
-        }
-
-        private static Dictionary<string, Image> GetImages(SpriteDocument sprite)
-        {
-            Dictionary<string, Image> images = new Dictionary<string, Image>();
-
-            foreach (string file in sprite.BundleAssets)
-            {
-                Image image = Image.FromFile(file);
-
-                // Only touch the resolution of the image if it isn't 96. 
-                // That way we keep the original image 'as is' in all other cases.
-                if (Math.Round(image.VerticalResolution) != 96F || Math.Round(image.HorizontalResolution) != 96F)
-                    image = new Bitmap(image);
-
-                images.Add(file, image);
-            }
-
-            return images;
-        }
+      return fragments;
     }
+
+    public async static Task<Dictionary<string, Image>> WatchFiles(SpriteDocument document, Func<string, bool, Task> updateSprite)
+    {
+      if (document == null)
+        return null;
+
+      Dictionary<string, Image> images = GetImages(document);
+
+      await new BundleFileObserver().AttachFileObserver(document, document.FileName, updateSprite);
+
+      foreach (string file in images.Keys)
+      {
+        await new BundleFileObserver().AttachFileObserver(document, file, updateSprite);
+      }
+
+      return images;
+    }
+    private static void Both(Dictionary<String, Image> images, List<SpriteFragment> fragments ,Graphics canvas, int margin)
+    {
+      int currentY = margin;
+      int currentX = margin;
+
+      var sqrt = Math.Sqrt(images.Count);
+
+      var rowHeight = images.Max(img => img.Value.Height);
+      var colWidth = images.Max(img => img.Value.Width);
+
+      var cols = Convert.ToInt32(sqrt);
+      // In this case, the remainder will create another row
+      Queue<String> imageQueue = new Queue<String>(images.Keys);
+
+      while (imageQueue.Count > 0)
+      {
+        for (var c = 0; c < cols && imageQueue.Count > 0; c++)
+        {
+          var imgKey = imageQueue.Dequeue();
+          Image img = images[imgKey];
+          fragments.Add(new SpriteFragment(imgKey, img.Width, img.Height, currentX, currentY));
+          canvas.DrawImage(img, currentX, currentY);
+          currentX += colWidth + margin;
+        }
+        currentY += rowHeight + margin;
+        currentX = margin;
+      }
+
+    }
+    private static void Vertical(Dictionary<string, Image> images, List<SpriteFragment> fragments, Graphics canvas, int margin)
+    {
+      int currentY = margin;
+
+      foreach (string file in images.Keys)
+      {
+        Image img = images[file];
+        fragments.Add(new SpriteFragment(file, img.Width, img.Height, margin, currentY));
+
+        canvas.DrawImage(img, margin, currentY);
+        currentY += img.Height + margin;
+      }
+    }
+
+    private static void Horizontal(Dictionary<string, Image> images, List<SpriteFragment> fragments, Graphics canvas, int margin)
+    {
+      int currentX = margin;
+
+      foreach (string file in images.Keys)
+      {
+        Image img = images[file];
+        fragments.Add(new SpriteFragment(file, img.Width, img.Height, currentX, margin));
+
+        canvas.DrawImage(img, currentX, margin);
+        currentX += img.Width + margin;
+      }
+    }
+
+    private static Dictionary<string, Image> GetImages(SpriteDocument sprite)
+    {
+      Dictionary<string, Image> images = new Dictionary<string, Image>();
+
+      foreach (string file in sprite.BundleAssets)
+      {
+        Image image = Image.FromFile(file);
+
+        // Only touch the resolution of the image if it isn't 96. 
+        // That way we keep the original image 'as is' in all other cases.
+        if (Math.Round(image.VerticalResolution) != 96F || Math.Round(image.HorizontalResolution) != 96F)
+          image = new Bitmap(image);
+
+        images.Add(file, image);
+      }
+
+      return images;
+    }
+  }
 }

--- a/EditorExtensions/Images/Sprite/SpriteGenerator.cs
+++ b/EditorExtensions/Images/Sprite/SpriteGenerator.cs
@@ -16,6 +16,7 @@ namespace MadsKristensen.EditorExtensions.Images
 
       var width = 0;
       var height = 0;
+      var cols = 0;
       
       if (document.Direction == SpriteDirection.Vertical)
       {
@@ -29,12 +30,11 @@ namespace MadsKristensen.EditorExtensions.Images
       }
       else if (document.Direction == SpriteDirection.Both)
       {
-        var sqrt = Math.Sqrt(images.Count);
-        var cols = Convert.ToInt32(Math.Floor(sqrt));
-        var rows = Math.Floor(sqrt) != Math.Ceiling(sqrt) ? cols + 1 : cols;
+        cols = Convert.ToInt32(Math.Ceiling(Math.Sqrt(images.Count)));
+        
         // In this case, the remainder will create another row
         width = (images.Values.Max(img => img.Width) * cols) + (document.Margin * cols) + document.Margin;
-        height = (images.Values.Max(img => img.Height) * rows) + (document.Margin * rows) + document.Margin;
+        height = (images.Values.Max(img => img.Height) * cols) + (document.Margin * cols) + document.Margin;
       }
 
       List<SpriteFragment> fragments = new List<SpriteFragment>();
@@ -46,7 +46,7 @@ namespace MadsKristensen.EditorExtensions.Images
           switch (document.Direction)
           {
           case SpriteDirection.Both:
-            Both(images, fragments, canvas, document.Margin);
+            Both(images, fragments, canvas, document.Margin, cols);
             break;
           case SpriteDirection.Horizontal:
             Horizontal(images, fragments, canvas, document.Margin);
@@ -80,7 +80,7 @@ namespace MadsKristensen.EditorExtensions.Images
 
       return images;
     }
-    private static void Both(Dictionary<String, Image> images, List<SpriteFragment> fragments ,Graphics canvas, int margin)
+    private static void Both(Dictionary<String, Image> images, List<SpriteFragment> fragments ,Graphics canvas, int margin, int cols)
     {
       int currentY = margin;
       int currentX = margin;
@@ -89,8 +89,6 @@ namespace MadsKristensen.EditorExtensions.Images
       var rowHeight = images.Max(img => img.Value.Height);
       var colWidth = images.Max(img => img.Value.Width);
 
-      var cols = Convert.ToInt32(Math.Floor(Math.Sqrt(images.Count)));
-      
       Queue<String> imageQueue = new Queue<String>(images.Keys);
 
       while (imageQueue.Count > 0)

--- a/EditorExtensions/Images/Sprite/SpriteGenerator.cs
+++ b/EditorExtensions/Images/Sprite/SpriteGenerator.cs
@@ -34,7 +34,7 @@ namespace MadsKristensen.EditorExtensions.Images
         var rows = Math.Floor(sqrt) != Math.Ceiling(sqrt) ? cols + 1 : cols;
         // In this case, the remainder will create another row
         width = (images.Values.Max(img => img.Width) * cols) + (document.Margin * cols) + document.Margin;
-        height = (images.Values.Max(img => img.Height) * (rows + 1)) + (document.Margin * (rows + 1)) + document.Margin;
+        height = (images.Values.Max(img => img.Height) * rows) + (document.Margin * rows) + document.Margin;
       }
 
       List<SpriteFragment> fragments = new List<SpriteFragment>();

--- a/EditorExtensions/Images/Sprite/SpriteGenerator.cs
+++ b/EditorExtensions/Images/Sprite/SpriteGenerator.cs
@@ -30,11 +30,13 @@ namespace MadsKristensen.EditorExtensions.Images
       }
       else if (document.Direction == SpriteDirection.Both)
       {
-        cols = Convert.ToInt32(Math.Ceiling(Math.Sqrt(images.Count)));
+        var sqrt = Math.Sqrt(images.Count);
+        cols = Convert.ToInt32(Math.Ceiling(sqrt));
+        var rows = (sqrt < (Math.Floor(sqrt) + 0.5)) ? cols - 1 : cols;
         
         // In this case, the remainder will create another row
         width = (images.Values.Max(img => img.Width) * cols) + (document.Margin * cols) + document.Margin;
-        height = (images.Values.Max(img => img.Height) * cols) + (document.Margin * cols) + document.Margin;
+        height = (images.Values.Max(img => img.Height) * rows) + (document.Margin * rows) + document.Margin;
       }
 
       List<SpriteFragment> fragments = new List<SpriteFragment>();
@@ -46,7 +48,7 @@ namespace MadsKristensen.EditorExtensions.Images
           switch (document.Direction)
           {
           case SpriteDirection.Both:
-            Both(images, fragments, canvas, document.Margin, cols);
+            Both(images, fragments, canvas, document.Margin);
             break;
           case SpriteDirection.Horizontal:
             Horizontal(images, fragments, canvas, document.Margin);
@@ -80,11 +82,11 @@ namespace MadsKristensen.EditorExtensions.Images
 
       return images;
     }
-    private static void Both(Dictionary<String, Image> images, List<SpriteFragment> fragments ,Graphics canvas, int margin, int cols)
+    private static void Both(Dictionary<String, Image> images, List<SpriteFragment> fragments ,Graphics canvas, int margin)
     {
       int currentY = margin;
       int currentX = margin;
-
+      var cols = Math.Ceiling(Math.Sqrt(images.Count));
       // Lazy way of making sure images don't overlap is to make ALL OF THEM to be the size of the largest one
       var rowHeight = images.Max(img => img.Value.Height);
       var colWidth = images.Max(img => img.Value.Width);

--- a/EditorExtensions/Settings/WESettings.cs
+++ b/EditorExtensions/Settings/WESettings.cs
@@ -44,8 +44,8 @@ namespace MadsKristensen.EditorExtensions.Settings
         public bool Optimize { get; set; }
 
         [Category("Sprite")]
-        [DisplayName("Is Vertical")]
-        [Description("Sprite image would be generated vertically. Set it to false, to generate it horizontally.")]
+        [DisplayName("Render Direction")]
+        [Description("Direction to render the sprite image. Default is vertically.")]
         [DefaultValue(SpriteDirection.Vertical)]
         public SpriteDirection Direction { get; set; }
 

--- a/EditorExtensions/Settings/WESettings.cs
+++ b/EditorExtensions/Settings/WESettings.cs
@@ -1,4 +1,5 @@
 ﻿using ConfOxide;
+using MadsKristensen.EditorExtensions.Images;
 using MarkdownSharp;
 using Microsoft.Ajax.Utilities;
 using System.Collections.ObjectModel;
@@ -45,8 +46,8 @@ namespace MadsKristensen.EditorExtensions.Settings
         [Category("Sprite")]
         [DisplayName("Is Vertical")]
         [Description("Sprite image would be generated vertically. Set it to false, to generate it horizontally.")]
-        [DefaultValue(true)]
-        public bool IsVertical { get; set; }
+        [DefaultValue(SpriteDirection.Vertical)]
+        public SpriteDirection Direction { get; set; }
 
         [Category("Sprite")]
         [DisplayName("Margin")]

--- a/EditorExtensions/Source.extension.vsixmanifest
+++ b/EditorExtensions/Source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="5fb7364d-2e8c-44a4-95eb-2a382e30fec9" Version="0.1.6.102" Language="en-US" Publisher="Mads Kristensen" />
+    <Identity Id="5fb7364d-2e8c-44a4-95eb-2a382e30fec9" Version="0.1.6.105" Language="en-US" Publisher="Mads Kristensen" />
     <DisplayName>Web Essentials 2015.0</DisplayName>
     <Description xml:space="preserve">Adds many useful features to Visual Studio for web developers.</Description>
     <MoreInfo>http://vswebessentials.com/</MoreInfo>

--- a/EditorExtensions/Source.extension.vsixmanifest
+++ b/EditorExtensions/Source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="5fb7364d-2e8c-44a4-95eb-2a382e30fec9" Version="0.1.6.105" Language="en-US" Publisher="Mads Kristensen" />
+    <Identity Id="5fb7364d-2e8c-44a4-95eb-2a382e30fec9" Version="0.1.6.106" Language="en-US" Publisher="Mads Kristensen" />
     <DisplayName>Web Essentials 2015.0</DisplayName>
     <Description xml:space="preserve">Adds many useful features to Visual Studio for web developers.</Description>
     <MoreInfo>http://vswebessentials.com/</MoreInfo>

--- a/EditorExtensions/Source.extension.vsixmanifest
+++ b/EditorExtensions/Source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="5fb7364d-2e8c-44a4-95eb-2a382e30fec9" Version="0.1.6.1" Language="en-US" Publisher="Mads Kristensen" />
+    <Identity Id="5fb7364d-2e8c-44a4-95eb-2a382e30fec9" Version="0.1.6.102" Language="en-US" Publisher="Mads Kristensen" />
     <DisplayName>Web Essentials 2015.0</DisplayName>
     <Description xml:space="preserve">Adds many useful features to Visual Studio for web developers.</Description>
     <MoreInfo>http://vswebessentials.com/</MoreInfo>

--- a/EditorExtensions/Source.extension.vsixmanifest
+++ b/EditorExtensions/Source.extension.vsixmanifest
@@ -1,29 +1,29 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
-    <Metadata>
-        <Identity Id="5fb7364d-2e8c-44a4-95eb-2a382e30fec9" Version="0.1.6.1" Language="en-US" Publisher="Mads Kristensen" />
-        <DisplayName>Web Essentials 2015.0</DisplayName>
-        <Description xml:space="preserve">Adds many useful features to Visual Studio for web developers.</Description>
-        <MoreInfo>http://vswebessentials.com/</MoreInfo>
-        <License>License.txt</License>
-        <GettingStartedGuide>http://vswebessentials.com/changelog</GettingStartedGuide>
-        <ReleaseNotes>http://vswebessentials.com/changelog</ReleaseNotes>
-        <Icon>Resources/Images/WebEssentials2012logo.png</Icon>
-        <PreviewImage>Resources/Images/preview.png</PreviewImage>
-        <Tags>css, javascript, html, json, markdown</Tags>
-    </Metadata>
-    <Installation InstalledByMsi="false">
-        <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="14.0.22310" />
-    </Installation>
-    <Dependencies>
-        <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="4.5" />
-        <Dependency Id="Microsoft.VisualStudio.MPF.14.0" DisplayName="Visual Studio MPF 14.0" d:Source="Installed" Version="14.0" />
-        <!--<Dependency d:Source="Installed" Id="0AC2ABB1-6383-4608-BA51-B58A23DD9E8A" DisplayName="Microsoft ASP.NET and Web Tools" Version="[12.3,12.4)" />-->
-    </Dependencies>
-    <Assets>
-        <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
-        <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="File" Path="registry.pkgdef" />
-        <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%|" />
-        <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="File" Path="JavaScript\Snippets\snippets.pkgdef" />
-    </Assets>
+  <Metadata>
+    <Identity Id="5fb7364d-2e8c-44a4-95eb-2a382e30fec9" Version="0.1.6.1" Language="en-US" Publisher="Mads Kristensen" />
+    <DisplayName>Web Essentials 2015.0</DisplayName>
+    <Description xml:space="preserve">Adds many useful features to Visual Studio for web developers.</Description>
+    <MoreInfo>http://vswebessentials.com/</MoreInfo>
+    <License>License.txt</License>
+    <GettingStartedGuide>http://vswebessentials.com/changelog</GettingStartedGuide>
+    <ReleaseNotes>http://vswebessentials.com/changelog</ReleaseNotes>
+    <Icon>Resources/Images/WebEssentials2012logo.png</Icon>
+    <PreviewImage>Resources/Images/preview.png</PreviewImage>
+    <Tags>css, javascript, html, json, markdown</Tags>
+  </Metadata>
+  <Installation InstalledByMsi="false">
+    <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="14.0.22310" />
+  </Installation>
+  <Dependencies>
+    <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="4.5" />
+    <Dependency Id="Microsoft.VisualStudio.MPF.14.0" DisplayName="Visual Studio MPF 14.0" d:Source="Installed" Version="14.0" />
+    <!--<Dependency d:Source="Installed" Id="0AC2ABB1-6383-4608-BA51-B58A23DD9E8A" DisplayName="Microsoft ASP.NET and Web Tools" Version="[12.3,12.4)" />-->
+  </Dependencies>
+  <Assets>
+    <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
+    <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="File" Path="registry.pkgdef" />
+    <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%|" />
+    <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="File" Path="JavaScript\Snippets\snippets.pkgdef" />
+  </Assets>
 </PackageManifest>

--- a/EditorExtensions/WebEssentials2015.csproj
+++ b/EditorExtensions/WebEssentials2015.csproj
@@ -469,6 +469,7 @@
     <Compile Include="Misc\Bundles\BundleGenerator.cs" />
     <Compile Include="Misc\Bundles\BundleDocument.cs" />
     <Compile Include="LiveScript\ContentType\LiveScriptContentTypeDefinition.cs" />
+    <None Include="PreBuildTask.cs" />
     <Compile Include="SCSS\Commands\ScssCreationListener.cs" />
     <Compile Include="SCSS\Commands\ScssExtractMixinCommandTarget.cs" />
     <Compile Include="SCSS\Commands\ScssExtractVariableCommandTarget.cs" />

--- a/EditorExtensions/WebEssentials2015.csproj
+++ b/EditorExtensions/WebEssentials2015.csproj
@@ -385,6 +385,7 @@
     <Compile Include="CSS\Completion\IconProviders\FoundationCompletionEntryGlyphProvider.cs" />
     <Compile Include="CSS\Validation\Filters\ExtendCssErrorFilter.cs" />
     <Compile Include="HTML\Completion\AriaIdCompletion.cs" />
+    <Compile Include="Images\Sprite\SpriteDirection.cs" />
     <Compile Include="JavaScript\Completion\GruntTaskCompletionSourceProvider.cs" />
     <Compile Include="NPM\MenuItems\AddGruntToProject.cs" />
     <Compile Include="Handlebars\ContentType\HandlebarsContentTypeDefinition.cs" />


### PR DESCRIPTION
Added the option of "Both" to render a square image instead of a very long vertical/horizontal one.

```   
Horizontal
x x x x x x x x x x x x

Vertical
x
x
x
x
x
x
x

Both
x x x x x 
x x x x x
x x x x x
x x x x x
x x x x x
x x x
```