### PR TITLE
Fixes wrong indentation in some codes related to the Markdown compiler

### DIFF
--- a/EditorExtensions/Settings/WESettings.cs
+++ b/EditorExtensions/Settings/WESettings.cs
@@ -694,21 +694,21 @@ namespace MadsKristensen.EditorExtensions.Settings
         [Description("Specifies a custom subfolder to save compiled files to. By default, compiled output will be placed in the same folder and nested under the original file.")]
         [DefaultValue(null)]
         public string OutputDirectory { get; set; }
-		#endregion
+        #endregion
 
-		[Category("Compile Options")]
-		[DisplayName("Render soft lines breaks as hard line breaks")]
-		[Description("When true, line breaks with ENTER key will be converted to proper HTML line breaks")]
-		[DefaultValue(false)]
-		public bool RenderSoftLineBreaksAsLineBreaks { get; set; }
+        [Category("Compile Options")]
+        [DisplayName("Render soft lines breaks as hard line breaks")]
+        [Description("When true, line breaks with ENTER key will be converted to proper HTML line breaks")]
+        [DefaultValue(false)]
+        public bool RenderSoftLineBreaksAsLineBreaks { get; set; }
 
-		[Category("Compile Options")]
-		[DisplayName("Keep track of the precise position of block and inline elements")]
-		[Description("When true, the parser tracks precise positions in the source data for block and inline elements. This is disabled by default because it incurs an additional performance cost to keep track of the original position")]
-		[DefaultValue(false)]
-		public bool TrackSourcePosition { get; set; }
+        [Category("Compile Options")]
+        [DisplayName("Keep track of the precise position of block and inline elements")]
+        [Description("When true, the parser tracks precise positions in the source data for block and inline elements. This is disabled by default because it incurs an additional performance cost to keep track of the original position")]
+        [DefaultValue(false)]
+        public bool TrackSourcePosition { get; set; }
 
-		[Category("Compilation")]
+        [Category("Compilation")]
         [DisplayName("Don't save raw compilation output")]
         [Description("Don't save separate unminified compiler output. This option has no effect when Minify On Save is disabled for HTML.")]
         [DefaultValue(false)]

--- a/EditorExtensions/Shared/Compilers/CompilerRunner.cs
+++ b/EditorExtensions/Shared/Compilers/CompilerRunner.cs
@@ -255,11 +255,11 @@ namespace MadsKristensen.EditorExtensions.Compilers
 
         protected async override Task<CompilerResult> RunCompilerAsync(string sourcePath, string targetPath)
         {
-			var cmSettings = new CommonMark.CommonMarkSettings()
-			{
-				RenderSoftLineBreaksAsLineBreaks = WESettings.Instance.Markdown.RenderSoftLineBreaksAsLineBreaks,
-				TrackSourcePosition = WESettings.Instance.Markdown.TrackSourcePosition
-			};			
+            var cmSettings = new CommonMark.CommonMarkSettings()
+            {
+                RenderSoftLineBreaksAsLineBreaks = WESettings.Instance.Markdown.RenderSoftLineBreaksAsLineBreaks,
+                TrackSourcePosition = WESettings.Instance.Markdown.TrackSourcePosition
+            };
             var result = CommonMark.CommonMarkConverter.Convert(await FileHelpers.ReadAllTextRetry(sourcePath), cmSettings);
 
             if (!string.IsNullOrEmpty(targetPath) &&


### PR DESCRIPTION
I'm sorry I didn't catch that when I sent the first PR. I just noticed I didn't have the right indentation set for VS 2015 yet and now the mixed tabs in the files are bugging me :confounded:

Not sure if you need a PR for that, but that's a way of fixing my own mess.