### PR TITLE
Correct Twitter card type

### DIFF
--- a/EditorExtensions/HTML/Completion/TwitterCardCompletion.cs
+++ b/EditorExtensions/HTML/Completion/TwitterCardCompletion.cs
@@ -15,7 +15,7 @@ namespace MadsKristensen.EditorExtensions.Html
         public TwitterCardCompletion()
             : base(new Dictionary<string, IEnumerable<string>>(StringComparer.OrdinalIgnoreCase)
             {
-                { "twitter:card",  Values("app", "gallery", "photo", "player", "product", "summary", "summary_large-image") }
+                { "twitter:card",  Values("app", "gallery", "photo", "player", "product", "summary", "summary_large_image") }
             }) { }
     }
 }


### PR DESCRIPTION
This commit fixes a typo in Twitter Card summary with large image
type key value. Having incorrect value here would prevent Twitter Card
from being validated on submission to Twitter for white-listing
This is a follow up to: http://git.io/hUDJ
Please see similar PR:
https://github.com/madskristensen/WebEssentials2013/pull/1810
Thanks!