### PR TITLE
Markdown Added Global HTML Template & CSS Option

### DIFF
--- a/EditorExtensions/Settings/WESettings.cs
+++ b/EditorExtensions/Settings/WESettings.cs
@@ -672,12 +672,6 @@ namespace MadsKristensen.EditorExtensions.Settings
     public sealed class MarkdownSettings : SettingsBase<MarkdownSettings>, ICompilerInvocationSettings, IMarginSettings
     {
         #region Compilation
-        [Category("Editor")]
-        [DisplayName("Show preview pane")]
-        [Description("Show a preview pane containing the rendered output in the editor.")]
-        [DefaultValue(true)]
-        public bool ShowPreviewPane { get; set; }
-
         [Category("Compilation")]
         [DisplayName("Compile files on save")]
         [Description("Compile files when saving them, if a compiled file already exists.")]
@@ -694,6 +688,27 @@ namespace MadsKristensen.EditorExtensions.Settings
         [Description("Specifies a custom subfolder to save compiled files to. By default, compiled output will be placed in the same folder and nested under the original file.")]
         [DefaultValue(null)]
         public string OutputDirectory { get; set; }
+        #endregion
+
+        #region Editor
+        [Category("Editor")]
+        [DisplayName("Show preview pane")]
+        [Description("Show a preview pane containing the rendered output in the editor.")]
+        [DefaultValue(true)]
+        public bool ShowPreviewPane { get; set; }
+
+        [Category("Editor")]
+        [DisplayName("Global CSS for Preview Pane")]
+        [Description("This CSS file will be applied to the preview pane so long as it's path is valid and there's no solution level custom css. To add a solution level CSS file, add a file with the filename ‘WE-Markdown.css’ in your solutions root directory. (Please note after setting this change, you'll need to close and reopen all markdown files)")]
+        [DefaultValue(null)]
+        public string GlobalPreviewCSSFile { get; set; }
+
+        [Category("Editor")]
+        [DisplayName("Global HTML Template for Preview Pane")]
+        [Description("This HTML template will be applied to the preview pane so long as it's path is valid and there's no solution level custom html template. To add a solution level html template file, add a file with the filename ‘WE-Markdown.html’ in your solutions root directory. (Please note after setting this change, you'll need to close and reopen all markdown files)")]
+        [DefaultValue(null)]
+        public string GlobalPreviewHtmlTemplate { get; set; }
+
         #endregion
 
         [Category("Compile Options")]


### PR DESCRIPTION
Bringing a change from Web Essentials 2013 over to 2015. See https://github.com/madskristensen/WebEssentials2013/pull/1835 for more information.

Please note that I modified the default html template. It adds a little text at the bottom and a hyperlink to let the user know they can customize the CSS & HTML Template of the preview. I can easily remove this, I just wanted some easy way to make the feature discover-able. Totally open to suggestions.

Also the 2013 feature didn't support global HTML template, this one does. 

If this pull is taken I'll update the vswebessentials website to talk about this new feature.

Thanks.