### PR TITLE
Validation: Add a switch to disable SEO microdata validation

### DIFF
--- a/EditorExtensions/BrowserLink/BestPractices/BestPracticesBrowserLink.cs
+++ b/EditorExtensions/BrowserLink/BestPractices/BestPracticesBrowserLink.cs
@@ -60,6 +60,10 @@ namespace MadsKristensen.EditorExtensions
 
             if (rule != null)
             {
+                // Force/fake the success flag if a specific validation is disabled
+                if (id == "microdata" && !Settings.WESettings.Instance.Html.EnableMicrodataValidation)
+                    success = true;
+
                 CreateTask(id, rule, success);
                 ErrorList.Tasks.Clear();
 

--- a/EditorExtensions/Settings/WESettings.cs
+++ b/EditorExtensions/Settings/WESettings.cs
@@ -312,6 +312,16 @@ namespace MadsKristensen.EditorExtensions.Settings
         //public string OutputDirectory { get; set; }
 
         //#endregion
+
+        #region Validations
+
+        [Category("Validations")]
+        [DisplayName("Enable microdata validation")]
+        [Description("Enable or disable SEO validation for microdata. Microdata helps adding semantic meaning to a website.")]
+        [DefaultValue(true)]
+        public bool EnableMicrodataValidation { get; set; }
+
+        #endregion
     }
 
     //public sealed class ImageDropFormat : SettingsBase<ImageDropFormat>


### PR DESCRIPTION
Add an setting option to disable validation about microdata.

![New option to disable SEO microdata validation](https://cloud.githubusercontent.com/assets/1680372/8223998/a23a8fd6-154d-11e5-9456-c0f8876791aa.png)

Turning this switch to false will remove this error message that can be useless for an intranet application per example.

    SEO: Use HTML5 microdata to add semantic meaning to the website.

This is a simple copy from this feature for WE2013 : madskristensen/WebEssentials2013#1888