### PR TITLE
Declare TS as const enum Fixes #67

### DIFF
--- a/EditorExtensions/Misc/CodeGeneration/IntellisenseWriter.cs
+++ b/EditorExtensions/Misc/CodeGeneration/IntellisenseWriter.cs
@@ -167,7 +167,7 @@ namespace MadsKristensen.EditorExtensions
 
                     if (io.IsEnum)
                     {
-                        sb.AppendLine("\tenum " + CamelCaseClassName(io.Name) + " {");
+                        sb.AppendLine("\tconst enum " + CamelCaseClassName(io.Name) + " {");
 
                         foreach (var p in io.Properties)
                         {


### PR DESCRIPTION
Add compatibility for TypeScript 1.5 by using `const` enum. This fixes issue #67