### PR TITLE
Fix C# Markdown embedding for Roslyn RTM

### DIFF
--- a/EditorExtensions/Markdown/Classify/RoslynEmbedder.cs
+++ b/EditorExtensions/Markdown/Classify/RoslynEmbedder.cs
@@ -27,7 +27,8 @@ namespace MadsKristensen.EditorExtensions.Markdown.Classify
 {
     public abstract class RoslynEmbedder : ICodeLanguageEmbedder
     {
-        public IReadOnlyCollection<string> GetBlockWrapper(IEnumerable<string> code) { return new string[0]; }
+        // TODO: Revert to empty array once Script is supported
+        public abstract IReadOnlyCollection<string> GetBlockWrapper(IEnumerable<string> code);
 
         static readonly string referenceAssemblyPath = Path.Combine(
             Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86),
@@ -75,7 +76,7 @@ namespace MadsKristensen.EditorExtensions.Markdown.Classify
                 var id = DocumentId.CreateNewId(projectId, debugName);
 
                 TryApplyChanges(CurrentSolution.AddDocument(
-                    id, debugName, 
+                    id, debugName,
                     TextLoader.From(buffer.AsTextContainer(), VersionStamp.Create())
                 ));
                 OpenDocument(id, buffer);
@@ -269,6 +270,15 @@ namespace MadsKristensen.EditorExtensions.Markdown.Classify
                          using System.Xml.Linq;";
             }
         }
+        public override IReadOnlyCollection<string> GetBlockWrapper(IEnumerable<string> code)
+        {
+            return new[] { @"partial class Entry
+                            {
+                                  async Task<object> SampleMethod" + Guid.NewGuid().ToString("n") + @"() {", @"
+                                return await Task.FromResult(new object());
+                            }
+                            }" };
+        }
     }
 
     [Export(typeof(ICodeLanguageEmbedder))]
@@ -294,6 +304,15 @@ namespace MadsKristensen.EditorExtensions.Markdown.Classify
                         Imports System.Xml
                         Imports System.Xml.Linq";
             }
+        }
+        public override IReadOnlyCollection<string> GetBlockWrapper(IEnumerable<string> code)
+        {
+            return new[] { @"
+                            Partial Class Entry
+                            Async Function SampleMethod" + Guid.NewGuid().ToString("n") + @"() As Task(Of Object)", @"
+                                Return Await Task.FromResult(New Object())
+                            End Function
+                            End Class" };
         }
     }
 }

--- a/EditorExtensions/Markdown/Classify/RoslynEmbedder.cs
+++ b/EditorExtensions/Markdown/Classify/RoslynEmbedder.cs
@@ -81,8 +81,7 @@ namespace MadsKristensen.EditorExtensions.Markdown.Classify
 
                 // Our GetFileName() extension (which should probably be deleted) doesn't work on projection buffers
                 var docInfo = DocumentInfo.Create(id, TextBufferExtensions.GetFileName(buffer) ?? "Markdown Embedded Code",
-                    loader: TextLoader.From(buffer.AsTextContainer(), VersionStamp.Create()),
-                    sourceCodeKind: SourceCodeKind.Script
+                    loader: TextLoader.From(buffer.AsTextContainer(), VersionStamp.Create())
                 );
                 OnDocumentAdded(docInfo);
                 OnDocumentOpened(id, buffer.AsTextContainer());

--- a/EditorExtensions/WebEssentials2015.csproj
+++ b/EditorExtensions/WebEssentials2015.csproj
@@ -85,57 +85,37 @@
     <Reference Include="ConfOxide">
       <HintPath>..\packages\ConfOxide.1.4.2.0\lib\net40\ConfOxide.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.CodeAnalysis">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.Common.1.0.0-rc1\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="Microsoft.CodeAnalysis, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CodeAnalysis.Common.1.0.0\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.CSharp">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.CSharp.1.0.0-rc1\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="Microsoft.CodeAnalysis.CSharp, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CodeAnalysis.CSharp.1.0.0\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.CSharp.Desktop">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.CSharp.1.0.0-rc1\lib\net45\Microsoft.CodeAnalysis.CSharp.Desktop.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.0.0\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.0.0-rc1\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="Microsoft.CodeAnalysis.EditorFeatures.Text, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CodeAnalysis.EditorFeatures.Text.1.0.0\lib\net45\Microsoft.CodeAnalysis.EditorFeatures.Text.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces.Desktop">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.0.0-rc1\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.Desktop.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="Microsoft.CodeAnalysis.VisualBasic, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CodeAnalysis.VisualBasic.1.0.0\lib\net45\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.Desktop">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.Common.1.0.0-rc1\lib\net45\Microsoft.CodeAnalysis.Desktop.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.0.0\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.EditorFeatures.Text">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.EditorFeatures.Text.1.0.0-rc1\lib\net45\Microsoft.CodeAnalysis.EditorFeatures.Text.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="Microsoft.CodeAnalysis.Workspaces, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.0.0\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.VisualBasic">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.VisualBasic.1.0.0-rc1\lib\net45\Microsoft.CodeAnalysis.VisualBasic.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Desktop">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.VisualBasic.1.0.0-rc1\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Desktop.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.0.0-rc1\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Workspaces.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces.Desktop">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.VisualBasic.Workspaces.1.0.0-rc1\lib\net45\Microsoft.CodeAnalysis.VisualBasic.Workspaces.Desktop.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.Workspaces">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.0.0-rc1\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Microsoft.CodeAnalysis.Workspaces.Desktop">
-      <HintPath>..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.0.0-rc1\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="Microsoft.CodeAnalysis.Workspaces.Desktop, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.0.0\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CSS.Core">
       <SpecificVersion>False</SpecificVersion>
@@ -192,9 +172,9 @@
     <Reference Include="Microsoft.VisualStudio.Language.Intellisense, Version=14.0.0.0">
       <Private>False</Private>
     </Reference>
-    <Reference Include="Microsoft.VisualStudio.LanguageServices">
-      <HintPath>..\packages\Microsoft.VisualStudio.LanguageServices.1.0.0-rc1\lib\net45\Microsoft.VisualStudio.LanguageServices.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="Microsoft.VisualStudio.LanguageServices, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.VisualStudio.LanguageServices.1.0.0\lib\net45\Microsoft.VisualStudio.LanguageServices.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Shell.14.0, Version=14.0.0.0">
       <Private>False</Private>
@@ -315,9 +295,9 @@
       <HintPath>..\packages\System.Collections.4.0.10-beta-22605\lib\net45\System.Collections.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="System.Collections.Immutable, Version=1.1.33.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <Private>False</Private>
-      <HintPath>..\packages\System.Collections.Immutable.1.1.33-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+    <Reference Include="System.Collections.Immutable, Version=1.1.36.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Collections.Immutable.1.1.36\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Composition.AttributedModel">
@@ -348,9 +328,9 @@
     <Reference Include="System.Net.Http.Formatting, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <Private>False</Private>
     </Reference>
-    <Reference Include="System.Reflection.Metadata">
-      <HintPath>..\packages\System.Reflection.Metadata.1.0.18-beta\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="System.Reflection.Metadata, Version=1.0.21.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Reflection.Metadata.1.0.21\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.Runtime">
       <HintPath>..\packages\System.Runtime.4.0.20-beta-22605\lib\net45\System.Runtime.dll</HintPath>
@@ -970,6 +950,7 @@
     <None Include="app.config">
       <SubType>Designer</SubType>
     </None>
+    <None Include="app.config" />
     <None Include="Markdown\Classify\Sample.md" />
     <None Include="packages.config" />
     <None Include="Resources\Images\Images.png" />
@@ -1058,10 +1039,9 @@
     </Page>
   </ItemGroup>
   <ItemGroup>
-    <Analyzer Include="..\packages\Microsoft.CodeAnalysis.Analyzers.1.0.0-rc1\tools\analyzers\C#\Microsoft.CodeAnalysis.CSharp.Analyzers.dll" />
-    <Analyzer Include="..\packages\Microsoft.CodeAnalysis.Analyzers.1.0.0-rc1\tools\analyzers\Microsoft.CodeAnalysis.Analyzers.dll" />
+    <Analyzer Include="..\packages\Microsoft.CodeAnalysis.Analyzers.1.0.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.Analyzers.dll" />
+    <Analyzer Include="..\packages\Microsoft.CodeAnalysis.Analyzers.1.0.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.Analyzers.dll" />
   </ItemGroup>
-  <ItemGroup />
   <PropertyGroup>
     <UseCodebase>true</UseCodebase>
   </PropertyGroup>

--- a/EditorExtensions/packages.config
+++ b/EditorExtensions/packages.config
@@ -3,22 +3,22 @@
   <package id="AjaxMin" version="5.14.5506.26202" targetFramework="net46" />
   <package id="CommonMark.NET" version="0.8.5" targetFramework="net46" />
   <package id="ConfOxide" version="1.4.2.0" targetFramework="net46" />
-  <package id="Microsoft.CodeAnalysis" version="1.0.0-rc1" targetFramework="net46" />
-  <package id="Microsoft.CodeAnalysis.Analyzers" version="1.0.0-rc1" targetFramework="net46" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.0.0-rc1" targetFramework="net46" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.0.0-rc1" targetFramework="net46" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.0.0-rc1" targetFramework="net46" />
-  <package id="Microsoft.CodeAnalysis.EditorFeatures.Text" version="1.0.0-rc1" targetFramework="net46" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.0.0-rc1" targetFramework="net46" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.0.0-rc1" targetFramework="net46" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.0.0-rc1" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis" version="1.0.0" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.Analyzers" version="1.0.0" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.0.0" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.0.0" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.0.0" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.EditorFeatures.Text" version="1.0.0" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.0.0" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.0.0" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.0.0" targetFramework="net46" />
   <package id="Microsoft.Composition" version="1.0.30" targetFramework="net46" />
-  <package id="Microsoft.VisualStudio.LanguageServices" version="1.0.0-rc1" targetFramework="net46" />
+  <package id="Microsoft.VisualStudio.LanguageServices" version="1.0.0" targetFramework="net46" />
   <package id="Minimatch" version="1.1.0" targetFramework="net451" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net46" />
   <package id="System.Collections" version="4.0.10-beta-22605" targetFramework="net46" />
-  <package id="System.Collections.Immutable" version="1.1.33-beta" targetFramework="net46" />
-  <package id="System.Reflection.Metadata" version="1.0.18-beta" targetFramework="net46" />
+  <package id="System.Collections.Immutable" version="1.1.36" targetFramework="net46" />
+  <package id="System.Reflection.Metadata" version="1.0.21" targetFramework="net46" />
   <package id="System.Runtime" version="4.0.20-beta-22605" targetFramework="net46" />
   <package id="TransientFaultHandling.Core" version="5.1.1209.1" targetFramework="net451" />
   <package id="WebMarkupMin.Core" version="0.9.11" targetFramework="net46" />

--- a/Rebracer.xml
+++ b/Rebracer.xml
@@ -81,6 +81,7 @@
         <PropertyValue name="RemoveParameters_PreviewReferenceChanges">1</PropertyValue>
         <PropertyValue name="RemoveUnusedUsings">1</PropertyValue>
         <PropertyValue name="RenameSmartTagEnabled">1</PropertyValue>
+        <PropertyValue name="RenameTrackingPreview">1</PropertyValue>
         <PropertyValue name="Rename_Comments">0</PropertyValue>
         <PropertyValue name="Rename_Overloads">0</PropertyValue>
         <PropertyValue name="Rename_Preview">0</PropertyValue>


### PR DESCRIPTION
Since Script is no longer supported, this is now more limiting.