### PR TITLE
Don't cause the CssEditorDocument to be recreated on demand

### DIFF
--- a/EditorExtensions/CSS/Validation/Providers/DisplayInlineErrorTagProvider.cs
+++ b/EditorExtensions/CSS/Validation/Providers/DisplayInlineErrorTagProvider.cs
@@ -35,14 +35,20 @@ namespace MadsKristensen.EditorExtensions.Css
                 doc.Tree.ItemsChanged += (sender, e) => { ItemsChanged(buffer, e); };
                 doc.Tree.TreeUpdated += Tree_TreeUpdated;
                 InitializeCache(doc.Tree.StyleSheet);
+
+                doc.Closing += Doc_Closing;
             }
         }
 
         public void SubjectBuffersDisconnected(IWpfTextView textView, ConnectionReason reason, Collection<ITextBuffer> subjectBuffers)
         {
-            foreach (ITextBuffer buffer in subjectBuffers)
+        }
+
+        private void Doc_Closing(object sender, EventArgs e)
+        {
+            CssEditorDocument doc = sender as CssEditorDocument;
+            if (doc != null)
             {
-                CssEditorDocument doc = CssEditorDocument.FromTextBuffer(buffer);
                 doc.Tree.TreeUpdated -= Tree_TreeUpdated;
             }
         }


### PR DESCRIPTION
When CssEditorDocument.FromTextBuffer is called in SubjectBuffersDisconnected, it creates a new CssEditorDocument on demand, because the real one has already been disposed. This is a potential source of memory leaks, but more specifically it causes debug assertion failures on a Debug build of WTE.