### PR TITLE
Apply Bower logo when displaying .bowerrc file

### DIFF
--- a/EditorExtensions/JSON/Adornments/LogoProvider.cs
+++ b/EditorExtensions/JSON/Adornments/LogoProvider.cs
@@ -21,6 +21,7 @@ namespace MadsKristensen.EditorExtensions.JSON
 
         private Dictionary<string, string> _map = new Dictionary<string, string>()
         {
+            { ".bowerrc", "bower.png" },
             { "bower.json", "bower.png"},
             { "package.json", "npm.png"},
             { "project.json", "vs.png"},


### PR DESCRIPTION
The Bower logo watermark is already displayed for the `bower.json` file. This PR extends that support to the associated `.bowerrc` file.