### PR TITLE
Find all references shouldn't stop the command chain when command is not handled

### DIFF
--- a/EditorExtensions/HTML/Commands/FindAllReferencesCommandTarget.cs
+++ b/EditorExtensions/HTML/Commands/FindAllReferencesCommandTarget.cs
@@ -28,9 +28,10 @@ namespace MadsKristensen.EditorExtensions.Html
             if (!string.IsNullOrEmpty(_className))
             {
                 FileHelpers.SearchFiles("." + _className, "*.css;*.less;*.scss;*.sass");
+				return true;
             }
 
-            return true;
+            return false;
         }
 
         private bool TryGetClassName(out string className)


### PR DESCRIPTION
Bugfix: This was preventing PHP Tools for Visual Studio to handle Find All references