### PR TITLE
HTML: Update WebMarkupMin to version 2.0.0

### DIFF
--- a/EditorExtensions/Misc/Minification/IFileMinifier.cs
+++ b/EditorExtensions/Misc/Minification/IFileMinifier.cs
@@ -6,8 +6,7 @@ using System.Threading.Tasks;
 using MadsKristensen.EditorExtensions.Settings;
 using Microsoft.Ajax.Utilities;
 using Microsoft.VisualStudio.Utilities;
-using WebMarkupMin.Core.Minifiers;
-using WebMarkupMin.Core.Settings;
+using WebMarkupMin.Core;
 
 namespace MadsKristensen.EditorExtensions.Optimization.Minification
 {
@@ -68,6 +67,8 @@ namespace MadsKristensen.EditorExtensions.Optimization.Minification
             var weHtmlSettings = WESettings.Instance.Html;
             var settings = new HtmlMinificationSettings
             {
+                PreserveCase = weHtmlSettings.PreserveCase,
+
                 // Tags
                 RemoveOptionalEndTags = false,
                 //EmptyTagRenderMode = HtmlEmptyTagRenderMode.Slash,

--- a/EditorExtensions/Settings/WESettings.cs
+++ b/EditorExtensions/Settings/WESettings.cs
@@ -260,6 +260,12 @@ namespace MadsKristensen.EditorExtensions.Settings
         public bool MinifyKnockoutBindingExpressions { get; set; }
 
         [Category("Minification")]
+        [DisplayName("Preserve case of tag and attribute names")]
+        [Description("Preserve case of HTML tag and attribute names during minification.")]
+        [DefaultValue(false)]
+        public bool PreserveCase { get; set; }
+
+        [Category("Minification")]
         [DisplayName("Processable script types")]
         [Description(@"Specify comma-separated list of types of script tags, that are processed by minifier (e.g. ""text/html, text/ng-template"").")]
         [DefaultValue(null)]

--- a/EditorExtensions/WebEssentials2015.csproj
+++ b/EditorExtensions/WebEssentials2015.csproj
@@ -343,8 +343,8 @@
     <Reference Include="System.Xaml" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
-    <Reference Include="WebMarkupMin.Core, Version=1.0.1.0, Culture=neutral, PublicKeyToken=99472178d266584b, processorArchitecture=MSIL">
-      <HintPath>..\packages\WebMarkupMin.Core.1.0.1\lib\net40\WebMarkupMin.Core.dll</HintPath>
+    <Reference Include="WebMarkupMin.Core, Version=2.0.0.0, Culture=neutral, PublicKeyToken=99472178d266584b, processorArchitecture=MSIL">
+      <HintPath>..\packages\WebMarkupMin.Core.2.0.0\lib\net452\WebMarkupMin.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="WindowsBase" />

--- a/EditorExtensions/packages.config
+++ b/EditorExtensions/packages.config
@@ -20,5 +20,5 @@
   <package id="System.Reflection.Metadata" version="1.0.21" targetFramework="net46" />
   <package id="System.Runtime" version="4.0.20-beta-22605" targetFramework="net46" />
   <package id="TransientFaultHandling.Core" version="5.1.1209.1" targetFramework="net451" />
-  <package id="WebMarkupMin.Core" version="1.0.1" targetFramework="net46" />
+  <package id="WebMarkupMin.Core" version="2.0.0" targetFramework="net46" />
 </packages>


### PR DESCRIPTION
Updated WebMarkupMin to version 2.0.0 and added `PreserveCase` property to HTML minification settings.

Unfortunately, I have not found in context menu commands for minification of files. Earlier for these purposes used `Web Essentials > Minify ... file(s)` commands.